### PR TITLE
fix: Show auto theme option from API 24 to API 28

### DIFF
--- a/source/core/model/src/main/kotlin/com/xayah/core/model/util/ModelUtil.kt
+++ b/source/core/model/src/main/kotlin/com/xayah/core/model/util/ModelUtil.kt
@@ -63,7 +63,7 @@ fun SelectionType.Companion.of(name: String?): SelectionType =
     runCatching { SelectionType.valueOf(name!!.uppercase()) }.getOrDefault(SelectionType.DEFAULT)
 
 fun ThemeType.Companion.of(name: String?): ThemeType =
-    runCatching { ThemeType.valueOf(name!!.uppercase()) }.getOrDefault(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) ThemeType.AUTO else ThemeType.LIGHT_THEME)
+    runCatching { ThemeType.valueOf(name!!.uppercase()) }.getOrDefault(ThemeType.AUTO)
 
 fun SmbAuthMode.Companion.indexOf(index: Int): SmbAuthMode = when (index) {
     1 -> SmbAuthMode.GUEST

--- a/source/feature/main/settings/src/main/kotlin/com/xayah/feature/main/settings/Item.kt
+++ b/source/feature/main/settings/src/main/kotlin/com/xayah/feature/main/settings/Item.kt
@@ -25,18 +25,18 @@ fun DarkThemeSelectable() {
         listOf(
             DialogRadioItem(
                 enum = ThemeType.AUTO,
-                title = StringResourceToken.fromStringId(R.string.theme_auto),
-                desc = StringResourceToken.fromStringId(R.string.theme_auto_desc),
+                title = context.getString(R.string.theme_auto),
+                desc = context.getString(R.string.theme_auto_desc),
             ),
             DialogRadioItem(
                 enum = ThemeType.LIGHT_THEME,
-                title = StringResourceToken.fromStringId(R.string.theme_light),
-                desc = StringResourceToken.fromStringId(R.string.theme_light_desc),
+                title = context.getString(R.string.theme_light),
+                desc = context.getString(R.string.theme_light_desc),
             ),
             DialogRadioItem(
                 enum = ThemeType.DARK_THEME,
-                title = StringResourceToken.fromStringId(R.string.theme_dark),
-                desc = StringResourceToken.fromStringId(R.string.theme_dark_desc),
+                title = context.getString(R.string.theme_dark),
+                desc = context.getString(R.string.theme_dark_desc),
             ),
         )
     }

--- a/source/feature/main/settings/src/main/kotlin/com/xayah/feature/main/settings/Item.kt
+++ b/source/feature/main/settings/src/main/kotlin/com/xayah/feature/main/settings/Item.kt
@@ -22,38 +22,23 @@ fun DarkThemeSelectable() {
     val context = LocalContext.current
     val dialogState = LocalSlotScope.current!!.dialogSlot
     val items = remember {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            listOf(
-                DialogRadioItem(
-                    enum = ThemeType.AUTO,
-                    title = context.getString(R.string.theme_auto),
-                    desc = context.getString(R.string.theme_auto_desc),
-                ),
-                DialogRadioItem(
-                    enum = ThemeType.LIGHT_THEME,
-                    title = context.getString(R.string.theme_light),
-                    desc = context.getString(R.string.theme_light_desc),
-                ),
-                DialogRadioItem(
-                    enum = ThemeType.DARK_THEME,
-                    title = context.getString(R.string.theme_dark),
-                    desc = context.getString(R.string.theme_dark_desc),
-                ),
-            )
-        } else {
-            listOf(
-                DialogRadioItem(
-                    enum = ThemeType.LIGHT_THEME,
-                    title = context.getString(R.string.theme_light),
-                    desc = context.getString(R.string.theme_light_desc),
-                ),
-                DialogRadioItem(
-                    enum = ThemeType.DARK_THEME,
-                    title = context.getString(R.string.theme_dark),
-                    desc = context.getString(R.string.theme_dark_desc),
-                ),
-            )
-        }
+        listOf(
+            DialogRadioItem(
+                enum = ThemeType.AUTO,
+                title = StringResourceToken.fromStringId(R.string.theme_auto),
+                desc = StringResourceToken.fromStringId(R.string.theme_auto_desc),
+            ),
+            DialogRadioItem(
+                enum = ThemeType.LIGHT_THEME,
+                title = StringResourceToken.fromStringId(R.string.theme_light),
+                desc = StringResourceToken.fromStringId(R.string.theme_light_desc),
+            ),
+            DialogRadioItem(
+                enum = ThemeType.DARK_THEME,
+                title = StringResourceToken.fromStringId(R.string.theme_dark),
+                desc = StringResourceToken.fromStringId(R.string.theme_dark_desc),
+            ),
+        )
     }
     val currentType by observeCurrentTheme()
     val currentIndex by remember(currentType) { mutableIntStateOf(items.indexOfFirst { it.enum == currentType }) }


### PR DESCRIPTION
Android 在 API 8 中引入了 [Night Mode](https://developer.android.com/reference/kotlin/android/app/UiModeManager#mode_night_auto) 支持，可实现日夜模式自动切换。因此跟随系统选项在 API 24 至 API 28 中可用。