### PR TITLE
Quality: fromJson assumes non-null Gson result and can crash on malformed or "null" payloads

### DIFF
--- a/source-next/app/src/main/java/com/xayah/databackup/adapter/WifiConfigurationAdapter.kt
+++ b/source-next/app/src/main/java/com/xayah/databackup/adapter/WifiConfigurationAdapter.kt
@@ -33,6 +33,7 @@ class WifiConfigurationAdapter {
 
     @FromJson
     fun fromJson(json: String): WifiConfiguration {
-        return mGson.fromJson(json, mType)
+        val config: WifiConfiguration? = mGson.fromJson(json, mType)
+        return requireNotNull(config) { "Invalid WifiConfiguration JSON: $json" }
     }
 }


### PR DESCRIPTION
## Problem

`Gson.fromJson` may return `null` (for example when the input is `"null"` or invalid for the target type), but `fromJson` declares a non-null `WifiConfiguration` return type and returns the platform type directly. This can surface as a runtime NPE when restoring backups with corrupted/edited JSON, causing restore flow crashes.


**Severity**: `high`
**File**: `source-next/app/src/main/java/com/xayah/databackup/adapter/WifiConfigurationAdapter.kt`

## Solution

Make deserialization null-safe and fail fast with an explicit error:

@FromJson
fun fromJson(json: String): WifiConfiguration {
    val config: WifiConfiguration? = mGson.fromJson(json, mType)
    return requireNotNull(config) { "Invalid WifiConfiguration JSON: $json" }
}

If callers can handle it, alternatively change return type to `WifiConfiguration?` and propagate null safely.


## Changes

- `source-next/app/src/main/java/com/xayah/databackup/adapter/WifiConfigurationAdapter.kt` (modified)

## Testing

- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced
